### PR TITLE
Add console detection summary for clothing inference script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ python src/detect_clothes.py path/to/image.jpg \
     --save-csv outputs/detections.csv
 ```
 
+After the command finishes it prints a short summary similar to:
+
+```
+Annotated image saved to: outputs/annotated.jpg
+Detections:
+  - dress | confidence=87.50% | box=(148.2, 83.6, 412.9, 512.0)
+  - shirt | confidence=74.12% | box=(23.5, 116.0, 201.8, 489.3)
+Detections saved to: outputs/detections.csv
+```
+
 ### Arguments
 
 | Flag | Description |

--- a/src/detect_clothes.py
+++ b/src/detect_clothes.py
@@ -179,6 +179,13 @@ def main() -> None:
 
     if not summary.detections:
         print("No clothing items were detected with the current confidence threshold.")
+    else:
+        print("Detections:")
+        for det in summary.detections:
+            print(
+                f"  - {det.label} | confidence={det.confidence:.2%} | "
+                f"box=({det.xmin:.1f}, {det.ymin:.1f}, {det.xmax:.1f}, {det.ymax:.1f})"
+            )
 
     if args.save_csv:
         save_csv(summary, args.save_csv)


### PR DESCRIPTION
## Summary
- print each detected clothing item with confidence and bounding box when running the detector
- document the new console summary output in the README for easier discovery

## Testing
- python -m compileall src/detect_clothes.py cloth_segmentation.py

------
https://chatgpt.com/codex/tasks/task_e_68d75caeb770832e9ccc094741bc8b05